### PR TITLE
Fix for modules being unit tested in a module environment

### DIFF
--- a/src/main/java/org/terasology/module/ModuleEnvironment.java
+++ b/src/main/java/org/terasology/module/ModuleEnvironment.java
@@ -219,7 +219,7 @@ public class ModuleEnvironment implements AutoCloseable, Iterable<Module> {
         }
         URL sourceUrl = type.getProtectionDomain().getCodeSource().getLocation();
         for (Module module : modules.values()) {
-            if (module.isOnClasspath() && module.getClasspaths().contains(sourceUrl)) {
+            if (module.isCodeModule() && module.getClasspaths().contains(sourceUrl)) {
                 return module.getId();
             }
         }


### PR DESCRIPTION
Improved getModuleProviding() to deal better with classes not originating from a ModuleClassLoader.
