### PR TITLE
Fixes Terasology issue #998

### DIFF
--- a/src/main/java/org/terasology/module/sandbox/ModuleSecurityPolicy.java
+++ b/src/main/java/org/terasology/module/sandbox/ModuleSecurityPolicy.java
@@ -31,17 +31,17 @@ public class ModuleSecurityPolicy extends Policy {
         return !(domain.getClassLoader() instanceof ModuleClassLoader) || super.implies(domain, permission);
     }
 
-	/**
-	 * Returns a modifiable Permissions collection, which is not used again, so JVisualVM can connect via RMI.
-	 */
-	@Override
+    /**
+     * Returns a modifiable Permissions collection, which is not used again, so JVisualVM can connect via RMI.
+     */
+    @Override
     public PermissionCollection getPermissions(CodeSource codesource) {
         return new Permissions();
     }
 
-	/**
-	 * Returns a modifiable Permissions collection, which is not used again, so JVisualVM can connect via RMI.
-	 */
+    /**
+     * Returns a modifiable Permissions collection, which is not used again, so JVisualVM can connect via RMI.
+     */
     @Override
     public PermissionCollection getPermissions(ProtectionDomain domain) {
         return new Permissions();

--- a/src/main/java/org/terasology/module/sandbox/ModuleSecurityPolicy.java
+++ b/src/main/java/org/terasology/module/sandbox/ModuleSecurityPolicy.java
@@ -30,4 +30,21 @@ public class ModuleSecurityPolicy extends Policy {
     public boolean implies(ProtectionDomain domain, Permission permission) {
         return !(domain.getClassLoader() instanceof ModuleClassLoader) || super.implies(domain, permission);
     }
+
+	/**
+	 * Returns a modifiable Permissions collection, which is not used again, so JVisualVM can connect via RMI.
+	 */
+	@Override
+    public PermissionCollection getPermissions(CodeSource codesource) {
+        return new Permissions();
+    }
+
+	/**
+	 * Returns a modifiable Permissions collection, which is not used again, so JVisualVM can connect via RMI.
+	 */
+    @Override
+    public PermissionCollection getPermissions(ProtectionDomain domain) {
+        return new Permissions();
+    }
+
 }


### PR DESCRIPTION
This is intended to fix the following issue:
https://github.com/MovingBlocks/Terasology/issues/998

After a bit of investigation, the policy permission set seems to be modified by some part deep down in the RMI server used by JVisualVM to connect. The Policy base class will return an unmodifiable collection, which then leads to the witnessed Exception that bubbles up to JVisualVM via the RMI connection.

By simply returning a one-off collection that can be modified, the exception is avoided and the JVisualVM can successfully connect (and profile) Terasology.
