### PR TITLE
Print module paths for debug logs only

### DIFF
--- a/src/main/java/org/terasology/module/sandbox/ModuleClassLoader.java
+++ b/src/main/java/org/terasology/module/sandbox/ModuleClassLoader.java
@@ -79,7 +79,7 @@ public class ModuleClassLoader extends URLClassLoader {
         pool = new ClassPool(ClassPool.getDefault());
         for (URL url : urls) {
             try {
-                logger.info("Module path: {}", Paths.get(url.toURI()).toString());
+                logger.debug("Module path: {}", Paths.get(url.toURI()).toString());
                 pool.appendClassPath(Paths.get(url.toURI()).toString());
             } catch (NotFoundException | URISyntaxException e) {
                 logger.error("Failed to process module url: {}", url);


### PR DESCRIPTION
I set the log level for printing module paths in `ModuleClassLoader` to `DEBUG` to reduce the amount on logging on startup.

As I understand it, this output is mainly for debugging.
