### PR TITLE
Avoid empty URL reflections warning

### DIFF
--- a/src/main/java/org/terasology/module/BaseModule.java
+++ b/src/main/java/org/terasology/module/BaseModule.java
@@ -147,10 +147,9 @@ public abstract class BaseModule implements Module {
             Path cachePath = archive.getPath(REFLECTIONS_CACHE_FILE);
             if (Files.isRegularFile(cachePath)) {
                 if (reflectionsFragment == null) {
-                    reflectionsFragment = new Reflections(new ConfigurationBuilder().addClassLoader(ClasspathHelper.staticClassLoader()));
-                }
-                try (InputStream stream = new BufferedInputStream(Files.newInputStream(cachePath))) {
-                    reflectionsFragment.collect(stream);
+                    try (InputStream stream = new BufferedInputStream(Files.newInputStream(cachePath))) {
+                        reflectionsFragment = new ConfigurationBuilder().getSerializer().read(stream);
+                    }
                 }
             }
         } catch (IOException e) {


### PR DESCRIPTION
Instead of creating an empty `Reflections` instance and merging a cached one, we should be able to directly use the latter. This also avoids printing that warning:

```
WARN  org.reflections.Reflections - given scan urls are empty. set urls in the configuration
```

Note that this change does no longer add the static class loader. As I understand it, this is not required since the data is loaded from the cache file anyway.
